### PR TITLE
(popular-movies): Rename result model

### DIFF
--- a/Movies+SwiftUI/Movies+SwiftUI/Features/MovieDetail/Views/MovieDetailScreen.swift
+++ b/Movies+SwiftUI/Movies+SwiftUI/Features/MovieDetail/Views/MovieDetailScreen.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MovieDetailScreen: View {
 
-    let movie: Result
+    let movie: PopularMovieResult
 
     var body: some View {
         Text(movie.title ?? "")

--- a/Movies+SwiftUI/Movies+SwiftUI/Features/PopularMovies/Models/PopularMovieModel.swift
+++ b/Movies+SwiftUI/Movies+SwiftUI/Features/PopularMovies/Models/PopularMovieModel.swift
@@ -4,7 +4,7 @@ import Foundation
 
 struct PopularMovie: Codable {
     let page: Int
-    let results: [Result]
+    let results: [PopularMovieResult]
     let totalPages, totalResults: Int
 
     enum CodingKeys: String, CodingKey {
@@ -16,7 +16,7 @@ struct PopularMovie: Codable {
 
 // MARK: - Result
 
-struct Result: Codable, Identifiable, Equatable {
+struct PopularMovieResult: Codable, Identifiable, Equatable {
     let adult: Bool?
     let backdropPath: String?
     let genreIDS: [Int]?

--- a/Movies+SwiftUI/Movies+SwiftUI/Features/PopularMovies/ViewModels/PopularMoviesViewModel.swift
+++ b/Movies+SwiftUI/Movies+SwiftUI/Features/PopularMovies/ViewModels/PopularMoviesViewModel.swift
@@ -31,7 +31,7 @@ class PopularMoviesViewModel: ObservableObject {
     }
 
     struct State {
-        var repos: [Result] = []
+        var repos: [PopularMovieResult] = []
         var page: Int = 1
         var canLoadNextPage = true
     }

--- a/Movies+SwiftUI/Movies+SwiftUI/Features/PopularMovies/Views/PopularMovieRow.swift
+++ b/Movies+SwiftUI/Movies+SwiftUI/Features/PopularMovies/Views/PopularMovieRow.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct PopularMovieRow: View {
 
-    let movie: Result
+    let movie: PopularMovieResult
     @State var progressValue: Float = 0.0
     @State private var isActive = false
 

--- a/Movies+SwiftUI/Movies+SwiftUI/Features/PopularMovies/Views/PopularMoviesList.swift
+++ b/Movies+SwiftUI/Movies+SwiftUI/Features/PopularMovies/Views/PopularMoviesList.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct PopularMoviesList: View {
 
-    let repos: [Result]
+    let repos: [PopularMovieResult]
     let isLoading: Bool
     let onScrolledAtBottom: () -> Void
 

--- a/Movies+SwiftUI/Movies+SwiftUI/Utils/Helper/Helper+Models.swift
+++ b/Movies+SwiftUI/Movies+SwiftUI/Utils/Helper/Helper+Models.swift
@@ -15,8 +15,8 @@ extension Helper {
                            title: String = "foo.title",
                            video: Bool = true,
                            voteAverage: Double = 0.5,
-                           voteCount: Int = 100) -> Result {
-        Result(adult: adult,
+                           voteCount: Int = 100) -> PopularMovieResult {
+        PopularMovieResult(adult: adult,
                backdropPath: backdropPath,
                genreIDS: genreIDS,
                id: id,


### PR DESCRIPTION
# ✨ What does this PR do?
The `Result` model is renamed to `PopularMovieResult` to provide a more descriptive name